### PR TITLE
Ticket #993: Added DMOV for motion set points

### DIFF
--- a/motionSetPointsApp/Db/motionSetPoints.db
+++ b/motionSetPointsApp/Db/motionSetPoints.db
@@ -235,6 +235,9 @@ record(calc, "$(P)POSITIONED")
 	field(CALC, "C==1?A:A&&B")
 }
 
+# The DMOV for POSN is the same as POSITIONED
+alias("$(P)POSITIONED", "$(P)POSN:DMOV")
+
 # epics string is 40 characters, so NELM in char waveform _POSITIONS is 40 * NELM in POSITIONS
 # need intermediate char waveform as ASYN does not do currently handle string waveforms
 

--- a/motionSetPoints_docs/motionSetPoints.rst
+++ b/motionSetPoints_docs/motionSetPoints.rst
@@ -62,6 +62,7 @@ The following PVs control the lookup:
 The following report what is going on:
 
 * **$(P)POSN** - The name of the current position. If not at an exact position, it will show the nearest.
+* **$(P)POSN:DMOV** - Equals 1 when the motion is complete, otherwise 0
 * **$(P)POSN:SP:RBV** - The name of the target position 
 * **$(P)COORD1** - The target position for the first motor
 * **$(P)COORD1:RBV** - The current position of the first motor


### PR DESCRIPTION
DMOV for POSN should be available so they can be accessed via a Block.

Can be tested on DEMO in motor_waitfor config:

camonitor IN:DEMO:LKUP:BEAMSTOP:POSN:DMOV
caput IN:DEMO:LKUP:BEAMSTOP:POSN In  (or Out)
