### PR TITLE
Added TOL back in

### DIFF
--- a/motionSetPointsApp/Db/motionSetPoints10Axis.substitutions
+++ b/motionSetPointsApp/Db/motionSetPoints10Axis.substitutions
@@ -1,7 +1,7 @@
 global {P="\$(P)", LOOKUP="\$(LOOKUP)"}
 file "$(TOP)/motionSetPointsApp/Db/motionSetPointsHeader.template" {
-	pattern{ AXIS0, AXIS1, AXIS2, AXIS3, AXIS4, AXIS5, AXIS6, AXIS7, AXIS8, AXIS9 }
-	{ "\$(AXIS0)", "\$(AXIS1)", "\$(AXIS2)", "\$(AXIS3)", "\$(AXIS4)", "\$(AXIS5)", "\$(AXIS6)", "\$(AXIS7)", "\$(AXIS8)", "\$(AXIS9)" }
+	pattern{ AXIS0, AXIS1, AXIS2, AXIS3, AXIS4, AXIS5, AXIS6, AXIS7, AXIS8, AXIS9, TOL }
+	{ "\$(AXIS0)", "\$(AXIS1)", "\$(AXIS2)", "\$(AXIS3)", "\$(AXIS4)", "\$(AXIS5)", "\$(AXIS6)", "\$(AXIS7)", "\$(AXIS8)", "\$(AXIS9)", "\$(TOL=1e10)" }
 }
 
 file "$(TOP)/motionSetPointsApp/Db/single_axis.template" {

--- a/motionSetPointsApp/Db/motionSetPointsDoubleAxis.substitutions
+++ b/motionSetPointsApp/Db/motionSetPointsDoubleAxis.substitutions
@@ -1,7 +1,7 @@
 global {P="\$(P)", LOOKUP="\$(LOOKUP)"}
 file "$(TOP)/motionSetPointsApp/Db/motionSetPointsHeader.template" {
-	pattern{ AXIS0, AXIS1 }
-	{ "\$(AXIS0)", "\$(AXIS1)" }
+	pattern{ AXIS0, AXIS1, TOL }
+	{ "\$(AXIS0)", "\$(AXIS1)", "\$(TOL=1e10)" }
 }
 
 file "$(TOP)/motionSetPointsApp/Db/single_axis.template" {

--- a/motionSetPointsApp/Db/motionSetPointsSingleAxis.substitutions
+++ b/motionSetPointsApp/Db/motionSetPointsSingleAxis.substitutions
@@ -1,7 +1,7 @@
 global {P="\$(P)", LOOKUP="\$(LOOKUP)"}
 file "$(TOP)/motionSetPointsApp/Db/motionSetPointsHeader.template" {
-	pattern{ AXIS0 }
-	{ "\$(AXIS0)" }
+	pattern{ AXIS0, TOL }
+	{ "\$(AXIS0)", "\$(TOL=1e10)" }
 }
 
 file "$(TOP)/motionSetPointsApp/Db/single_axis.template" {


### PR DESCRIPTION
TOL is passed through by the `.cmd` file to set how close you need to be to say that you're at a named position. The substitutions file was overwriting it and not allowing it to be set.

To test:
* Run make clean uninstall && make
* Confirm the individual db files have `$(TOL)` in them so you can specify it on load