### PR TITLE
Ticket6425 add file checks

### DIFF
--- a/motionSetPointsApp/Db/motionSetPointsHeader.template
+++ b/motionSetPointsApp/Db/motionSetPointsHeader.template
@@ -145,6 +145,24 @@ record(longin, "$(P)POSN:NUM")
 	field(EGU, "")
 }
 
+record(stringin, "$(P)FILENAME")
+{
+	field(DESC, "The name of the motion setpoints file")
+	field(DTYP, "asynOctetRead")
+	field(INP,"@asyn($(LOOKUP),0)FILENAME")
+	field(SCAN, "I/O Intr")
+	field(UDFS, "NO_ALARM")
+}
+
+record(stringin, "$(P)ERRORMSG")
+{
+	field(DESC, "Current error message")
+	field(DTYP, "asynOctetRead")
+	field(INP,"@asyn($(LOOKUP),0)ERRORMSG")
+	field(SCAN, "I/O Intr")
+	field(UDFS, "NO_ALARM")
+}
+
 ## how close we must be to a position to be considered at that position
 ## we also wait for motion to stop, so a large value here will just mean we
 ## are in positon once we have (1) stopped moving and the (2) the target position 

--- a/motionSetPointsApp/src/motionSetPoints.cpp
+++ b/motionSetPointsApp/src/motionSetPoints.cpp
@@ -80,11 +80,6 @@ motionSetPoints::motionSetPoints(const char *portName, const char* fileName, int
         m_currentCoordinates.push_back(0.0);
     }
 
-    setStringParam(P_errorMsg, "");
-    // m_fileName is the full path to the file, and as we have a limit of 40 characters we extract just the file name.
-    auto name = strrchr(m_fileName.c_str(), '/') ? strrchr(m_fileName.c_str(), '/') + 1 : m_fileName.c_str();
-    setStringParam(P_fileName, name);
-
     loadDefFile(m_fileName.c_str(), numberOfCoordinates);
 	updateAvailablePositions();
 }
@@ -136,6 +131,7 @@ void motionSetPoints::updateAvailablePositions()
 	setStringParam(P_positions, buffer);
     setIntegerParam(P_numpos, static_cast<int>(numPositions(m_fileName.c_str())));
     setDoubleParam(P_numAxes, m_currentCoordinates.size());
+    setStringParam(P_fileName, getFileName(m_fileName.c_str()));
     setStringParam(P_errorMsg, getErrorMsg(m_fileName.c_str()));
 }
 

--- a/motionSetPointsApp/src/motionSetPoints.cpp
+++ b/motionSetPointsApp/src/motionSetPoints.cpp
@@ -30,8 +30,7 @@ static const char *driverName = "motionSetPoints";
 
 motionSetPoints::motionSetPoints(const char *portName, const char* fileName, int numberOfCoordinates) 
    : asynPortDriver(portName, 
-                    numberOfCoordinates, /* maxAddr */ 
-                    NUM_MSP_PARAMS, /* num parameters */
+                    numberOfCoordinates, /* maxAddr */
                     asynInt32Mask | asynFloat64Mask | asynOctetMask | asynDrvUserMask, /* Interface mask */
                     asynInt32Mask | asynFloat64Mask | asynOctetMask,  /* Interrupt mask */
                     ASYN_CANBLOCK, /* asynFlags.  This driver can block but it is not multi-device */

--- a/motionSetPointsApp/src/motionSetPoints.cpp
+++ b/motionSetPointsApp/src/motionSetPoints.cpp
@@ -59,6 +59,10 @@ motionSetPoints::motionSetPoints(const char *portName, const char* fileName, int
 	createParam(P_coordString, asynParamFloat64, &P_coord);
     createParam(P_coordRBVString, asynParamFloat64, &P_coordRBV);
 
+    // File information.
+    createParam(P_fileNameString, asynParamOctet, &P_fileName);
+    createParam(P_errorMsgString, asynParamOctet, &P_errorMsg);
+
 	// initial values
     setStringParam(P_posn, "");
     setStringParam(P_nearestPosn, "");
@@ -75,6 +79,11 @@ motionSetPoints::motionSetPoints(const char *portName, const char* fileName, int
         setDoubleParam(i, P_coordRBV, 0.0);
         m_currentCoordinates.push_back(0.0);
     }
+
+    setStringParam(P_errorMsg, "");
+    // m_fileName is the full path to the file, and as we have a limit of 40 characters we extract just the file name.
+    auto name = strrchr(m_fileName.c_str(), '/') ? strrchr(m_fileName.c_str(), '/') + 1 : m_fileName.c_str();
+    setStringParam(P_fileName, name);
 
     loadDefFile(m_fileName.c_str(), numberOfCoordinates);
 	updateAvailablePositions();
@@ -127,6 +136,7 @@ void motionSetPoints::updateAvailablePositions()
 	setStringParam(P_positions, buffer);
     setIntegerParam(P_numpos, static_cast<int>(numPositions(m_fileName.c_str())));
     setDoubleParam(P_numAxes, m_currentCoordinates.size());
+    setStringParam(P_errorMsg, getErrorMsg(m_fileName.c_str()));
 }
 
 /* Asyn driver entry point for any writeFloat64 PVs.

--- a/motionSetPointsApp/src/motionSetPoints.h
+++ b/motionSetPointsApp/src/motionSetPoints.h
@@ -38,6 +38,10 @@ private:
 #define FIRST_MSP_PARAM P_positions
 #define LAST_MSP_PARAM P_coordRBV
 
+    // File information.
+    int P_fileName; // string - motio setpoints file name
+    int P_errorMsg; // string - error message
+
 	void updateAvailablePositions();
     void updateCurrPosn();
     int gotoPosition(const char* value);
@@ -62,5 +66,7 @@ private:
 #define P_numAxesString     "NUMAXES"
 #define P_tolString         "TOL"
 #define P_posDiffString     "POSDIFF"
+#define P_fileNameString    "FILENAME"
+#define P_errorMsgString    "ERRORMSG"
 
 #endif /* MOTIONSETPOINTS_H */

--- a/motionSetPointsApp/src/motionSetPoints.h
+++ b/motionSetPointsApp/src/motionSetPoints.h
@@ -35,8 +35,6 @@ private:
     // Parameters for each coordinate, these will be set on each of the addresses
     int P_coord; // double - current position of co-ordinate
     int P_coordRBV;  // double - requested position of co-ordinate
-#define FIRST_MSP_PARAM P_positions
-#define LAST_MSP_PARAM P_coordRBV
 
     // File information.
     int P_fileName; // string - motio setpoints file name
@@ -47,8 +45,6 @@ private:
     int gotoPosition(const char* value);
 	
 };
-
-#define NUM_MSP_PARAMS (&LAST_MSP_PARAM - &FIRST_MSP_PARAM + 1)
 
 #define P_positionsString	"POSITIONS"
 #define P_posnSPRBVString	"POSNSPRBV"

--- a/motionSetPointsApp/src/setPoint.cpp
+++ b/motionSetPointsApp/src/setPoint.cpp
@@ -193,7 +193,7 @@ void loadFile(FileIOInterface *fileIO, const char *fname, const char *env_fname,
                 read_names.insert(row.name);
             }
             catch (std::exception e) {
-                if (table.error.empty()) {
+                if (table.error == "No error") {
                     table.error = "Error parsing file.";
                 }
 

--- a/motionSetPointsApp/src/setPoint.cpp
+++ b/motionSetPointsApp/src/setPoint.cpp
@@ -150,7 +150,7 @@ void loadFile(FileIOInterface *fileIO, const char *fname, const char *env_fname,
     table.error = "No error";
     // "fname" is the full path to the file, and as there is a limit of 40 characters, extract just the file name.
     std::string fnameString = fname;
-    size_t lastSeparator = fnameString.find_last_of("\\/", std::string::npos, 2);
+    size_t lastSeparator = fnameString.find_last_of("\\/");
     if (lastSeparator != std::string::npos) {
         fnameString = fnameString.substr(lastSeparator + 1);
     }

--- a/motionSetPointsApp/src/setPoint.cpp
+++ b/motionSetPointsApp/src/setPoint.cpp
@@ -148,8 +148,13 @@ void loadFile(FileIOInterface *fileIO, const char *fname, const char *env_fname,
     epicsGuard<epicsMutex> _lock(g_lock); // need to protect write access to map	
 	table.rows.clear();
     table.error = "No error";
-    // "fname" is the full path to the file, and as we have a limit of 40 characters we extract just the file name.
-    table.fileName = strrchr(fname, '/') ? strrchr(fname, '/') + 1 : fname;
+    // "fname" is the full path to the file, and as there is a limit of 40 characters, extract just the file name.
+    std::string fnameString = fname;
+    size_t lastSeparator = fnameString.find_last_of("\\/", std::string::npos, 2);
+    if (lastSeparator != std::string::npos) {
+        fnameString = fnameString.substr(lastSeparator + 1);
+    }
+    table.fileName = fnameString;
 
     if (!fileIO->Verify()) {
         table.error = "No new line at end of file.";

--- a/motionSetPointsApp/src/setPoint.hpp
+++ b/motionSetPointsApp/src/setPoint.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <fstream>
 
 #define NAME_LEN 40
 
@@ -13,6 +14,19 @@ public:
     virtual bool ReadLine(std::string &str) = 0;
     virtual void Close() = 0;
     virtual bool isOpen() = 0;
+    virtual bool Verify() = 0;
+};
+
+class FileIO : public FileIOInterface {
+public:
+    virtual void Open(const char* filename) override;
+    virtual bool ReadLine(std::string& str) override;
+    virtual void Close() override;
+    virtual bool isOpen() override;
+    virtual bool Verify() override;
+
+private:
+    std::ifstream m_file;
 };
 
 // A row in the lookup file
@@ -28,6 +42,8 @@ typedef struct LookupTable {
 
 	LookupRow *pRowRBV;		// The requested row to move to
 	LookupRow *pRowCurr;	// The current row we are at as we move to above requested position
+
+    std::string error;
 	
 	LookupTable() : pRowRBV(NULL), pRowCurr(NULL) {}
 } LookupTable;
@@ -45,5 +61,6 @@ void getPositions(std::string *target, const char* env_fname);
 std::string getPositionByIndex(int pos, const char* env_fname);
 int getPositionIndexByName(const char* name, const char* env_fname);
 size_t numPositions(const char* env_fname);
+std::string getErrorMsg(const char* env_fname);
 
 #endif

--- a/motionSetPointsApp/src/setPoint.hpp
+++ b/motionSetPointsApp/src/setPoint.hpp
@@ -43,6 +43,7 @@ typedef struct LookupTable {
 	LookupRow *pRowRBV;		// The requested row to move to
 	LookupRow *pRowCurr;	// The current row we are at as we move to above requested position
 
+    std::string fileName;
     std::string error;
 	
 	LookupTable() : pRowRBV(NULL), pRowCurr(NULL) {}
@@ -61,6 +62,7 @@ void getPositions(std::string *target, const char* env_fname);
 std::string getPositionByIndex(int pos, const char* env_fname);
 int getPositionIndexByName(const char* name, const char* env_fname);
 size_t numPositions(const char* env_fname);
+std::string getFileName(const char* env_fname);
 std::string getErrorMsg(const char* env_fname);
 
 #endif

--- a/motionSetPointsApp/src/tests/testSetPoint.cc
+++ b/motionSetPointsApp/src/tests/testSetPoint.cc
@@ -20,6 +20,7 @@ namespace {
         MOCK_METHOD1(ReadLine, bool(std::string &str));
         MOCK_METHOD0(Close, void());
         MOCK_METHOD0(isOpen, bool());
+        MOCK_METHOD0(Verify, bool());
     };
 
     TEST(setPoint, GIVEN_file_line_with_one_coord_WHEN_row_created_THEN_correct_name_and_coords) {
@@ -64,10 +65,11 @@ namespace {
         loadFile(&mockFile, testFilename, "TEST", 1);
     }
 
-    void createMockFile(MockFileIO* mockFile, std::string testFileName, std::vector<std::string> linesInFile, bool expectedToGetToEnd=true) {
+    void createMockFile(MockFileIO* mockFile, std::string testFileName, std::vector<std::string> linesInFile, bool expectedToGetToEnd=true, bool hasNewLine=true) {
         InSequence seq;
         EXPECT_CALL(*mockFile, Open(StrEq(testFileName)));
         EXPECT_CALL(*mockFile, isOpen()).WillOnce(Return(true));
+        EXPECT_CALL(*mockFile, Verify()).WillOnce(Return(hasNewLine));
 
         for (auto line : linesInFile) {
             EXPECT_CALL(*mockFile, ReadLine(_)).WillOnce(DoAll(SetArgReferee<0>(line), Return(true)));
@@ -491,6 +493,34 @@ namespace {
         getPositions(&positions, envFilename);
 
         ASSERT_EQ(positions, "a_very_much_longer_name                 short_name                              ");
+    }
+
+    TEST(setPoint, GIVEN_file_without_new_line_at_end_WHEN_loadFile_called_THEN_table_empty) {
+        auto testFilename = "my_file";
+        auto envFilename = "TEST";
+        std::vector<std::string> fileLines = {};
+        MockFileIO mockFile;
+
+        createMockFile(&mockFile, testFilename, fileLines, false, false);
+
+        loadFile(&mockFile, testFilename, envFilename, 1);
+
+        auto table = getTable(envFilename);
+
+        ASSERT_EQ(table.rows.size(), 0);
+    }
+
+    TEST(setPoint, GIVEN_file_without_new_line_at_end_WHEN_Verify_called_THEN_returns_false) {
+        auto testFilename = "my_file.txt";
+        std::ofstream os(testFilename);
+        os << "Test data with no new line at end";
+
+        FileIO testFile;
+        testFile.Open(testFilename);
+        
+        std::remove(testFilename);
+
+        ASSERT_FALSE(testFile.Verify());
     }
 
 } // namespace

--- a/motionSetPointsApp/src/tests/testSetPoint.cc
+++ b/motionSetPointsApp/src/tests/testSetPoint.cc
@@ -510,6 +510,8 @@ namespace {
         ASSERT_EQ(table.rows.size(), 0);
     }
 
+    // FileIO tests.
+
     TEST(setPoint, GIVEN_file_without_new_line_at_end_WHEN_Verify_called_THEN_returns_false) {
         auto testFilename = "my_file.txt";
         std::ofstream os(testFilename);
@@ -517,10 +519,42 @@ namespace {
 
         FileIO testFile;
         testFile.Open(testFilename);
-        
+
         std::remove(testFilename);
 
         ASSERT_FALSE(testFile.Verify());
+    }
+
+    TEST(setPoint, GIVEN_loaded_file_WHEN_getFileName_called_THEN_expected_name_string_set) {
+        auto testFilename = "my_file.txt";
+        auto envFilename = "TEST";
+        std::ofstream os(testFilename);
+        os << "Position 1\n";
+
+        FileIO testFile;
+        testFile.Open(testFilename);
+
+        std::remove(testFilename);
+
+        loadFile(&testFile, testFilename, envFilename, 1);
+
+        ASSERT_TRUE(getFileName(envFilename) == testFilename);
+    }
+
+    TEST(setPoint, GIVEN_file_with_invalid_contents_WHEN_loadFile_called_THEN_error_string_set) {
+        auto testFilename = "my_file.txt";
+        auto envFilename = "TEST";
+        std::ofstream os(testFilename);
+        os << "I have the wrong format.";
+
+        FileIO testFile;
+        testFile.Open(testFilename);
+
+        std::remove(testFilename);
+
+        loadFile(&testFile, testFilename, envFilename, 1);
+
+        ASSERT_FALSE(getErrorMsg(envFilename).empty());
     }
 
 } // namespace


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6425.

Description:

- We now send the errors when processing the motion setpoints file to the OPI.
- We also send the file name to the OPI.
- Fixed an issue where a `std::stod` exception was not being caught.

To test:

- Run the new tests using `make runtests`.
- Run the IOC `motion_setpoints` test.